### PR TITLE
Add support for reading floating point formats (Ruby Runtime)

### DIFF
--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -183,6 +183,26 @@ class Stream
   end
 
   # ========================================================================
+  # Floating point
+  # ========================================================================
+  
+  def read_f4le
+    read_bytes(4).unpack('e')[0]
+  end
+  
+  def read_f8le
+    read_bytes(8).unpack('E')[0]
+  end
+  
+  def read_f4be
+    read_bytes(4).unpack('g')[0]
+  end
+  
+  def read_f8be
+    read_bytes(8).unpack('G')[0]
+  end
+
+  # ========================================================================
 
   def read_bytes_full
     @_io.read


### PR DESCRIPTION
Going by the [unpack method docs](http://apidock.com/ruby/String/unpack):

    Directive    | Returns | Meaning
    -----------------------------------------------------------------
       E         | Float   | double-precision, little-endian byte order
       e         | Float   | single-precision, little-endian byte order
       G         | Float   | double-precision, network (big-endian) byte order
       g         | Float   | single-precision, network (big-endian) byte order