### PR TITLE
Output HEX-bytes instead of letters for ValidationNotEqualError.

### DIFF
--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -558,6 +558,14 @@ end
 # Common ancestor for all validation failures. Stores pointer to
 # KaitaiStream IO object which was involved in an error.
 class ValidationFailedError < KaitaiStructError
+  def self.strToHex(str)
+    str
+      .split(//)
+      .map { |b| b.unpack('H2')[0] }
+      .inspect()
+      .gsub(/[",]/, '')
+  end
+
   def initialize(msg, io, src_path)
     super("at pos #{io.pos}: validation failed: #{msg}", src_path)
     @io = io
@@ -569,7 +577,7 @@ end
 # "expected", but it turned out that it's not.
 class ValidationNotEqualError < ValidationFailedError
   def initialize(expected, actual, io, src_path)
-    super("not equal, expected #{expected.unpack("H*")}, but got #{actual.unpack("H*")}", io, src_path)
+    super("not equal, expected #{self.class.strToHex(expected)}, but got #{self.class.strToHex(actual)}", io, src_path)
     @expected = expected
     @actual = actual
   end

--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -558,14 +558,6 @@ end
 # Common ancestor for all validation failures. Stores pointer to
 # KaitaiStream IO object which was involved in an error.
 class ValidationFailedError < KaitaiStructError
-  def self.strToHex(str)
-    str
-      .split(//)
-      .map { |b| b.unpack('H2')[0] }
-      .inspect()
-      .gsub(/[",]/, '')
-  end
-
   def initialize(msg, io, src_path)
     super("at pos #{io.pos}: validation failed: #{msg}", src_path)
     @io = io
@@ -577,7 +569,7 @@ end
 # "expected", but it turned out that it's not.
 class ValidationNotEqualError < ValidationFailedError
   def initialize(expected, actual, io, src_path)
-    super("not equal, expected #{self.class.strToHex(expected)}, but got #{self.class.strToHex(actual)}", io, src_path)
+    super("not equal, expected [#{Stream.format_hex(expected)}], but got [#{Stream.format_hex(actual)}]", io, src_path)
     @expected = expected
     @actual = actual
   end

--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -569,7 +569,7 @@ end
 # "expected", but it turned out that it's not.
 class ValidationNotEqualError < ValidationFailedError
   def initialize(expected, actual, io, src_path)
-    super("not equal, expected #{expected.inspect}, but got #{actual.inspect}", io, src_path)
+    super("not equal, expected #{expected.unpack("H*")}, but got #{actual.unpack("H*")}", io, src_path)
     @expected = expected
     @actual = actual
   end


### PR DESCRIPTION
That's what's done in Java as well and the current implementation pretty much reflects the same approaches implemented like in Java with the same formatted output. The following is an example error message in Java:

> 2020-12-02 13:24:12,501 ERROR
> de.am_soft.util.backend.client.ClBase.callImpl: Exception occurred during method invocation.
> org.apache.axis2.AxisFault: /seq/1: at pos 17: validation failed:
> not equal, expected [2f 2f], but got [09 37]

And the following screenshots provide BEFORE and AFTER in Ruby:

![Clipboard01](https://user-images.githubusercontent.com/6223655/101383643-af889080-38b9-11eb-9a78-af943b0563ca.jpg)

vs.

![Clipboard01](https://user-images.githubusercontent.com/6223655/101460145-7bed4b00-3939-11eb-886f-72420692549f.jpg)

> C:/Users/TSCHOE~1/AppData/Local/Temp/d20201208-6932-1sqhtjx/par_oms_tpl_short_opt_aes_verify.rb:95:in `_read': /seq/1:
> at pos 17: validation failed: not equal, expected [2f 2f], but got [09 37] (Kaitai::Struct::ValidationNotEqualError)

This fixes https://github.com/kaitai-io/kaitai_struct_ruby_runtime/issues/4.