### PR TITLE
Make ValidationNotEqualError throw HEX-bytes in case of given byte arrays.

### DIFF
--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -533,7 +533,7 @@ class Stream
   end
 
   ###
-  # Guess about given args being byte arrays most likely.
+  # Guess if the given args are most likely byte arrays.
   # <p>
   # There's no way to know for sure, but {@code Encoding::ASCII_8BIT} is a special encoding that is
   # usually used for a byte array(/string), not a character string. For those reasons, that encoding

--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -569,7 +569,12 @@ end
 # "expected", but it turned out that it's not.
 class ValidationNotEqualError < ValidationFailedError
   def initialize(expected, actual, io, src_path)
-    super("not equal, expected [#{Stream.format_hex(expected)}], but got [#{Stream.format_hex(actual)}]", io, src_path)
+    begin
+      super("not equal, expected [#{Stream.format_hex(expected)}], but got [#{Stream.format_hex(actual)}]", io, src_path)
+    rescue  NoMethodError => e
+      super("not equal, expected #{expected.inspect}, but got #{actual.inspect}", io, src_path)
+    end
+
     @expected = expected
     @actual = actual
   end

--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -569,7 +569,7 @@ end
 # "expected", but it turned out that it's not.
 class ValidationNotEqualError < ValidationFailedError
   def initialize(expected, actual, io, src_path)
-    super("not equal, expected #{expected.inspect}, but got #{actual.inspect}", io, src_path)
+    super("not equal, expected [#{Stream.format_hex(expected)}], but got [#{Stream.format_hex(actual)}]", io, src_path)
     @expected = expected
     @actual = actual
   end

--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -533,11 +533,11 @@ class Stream
   end
 
   ###
-  # Guess about given arg being a byte-array most likely.
+  # Guess about given args being byte arrays most likely.
   # <p>
-  # There's no way to know for sure in Ruby, because the type {@code String} is used in both cases,
-  # but especially in the context of KS things are differently likely. This especially means that an
-  # encoding of {@code ASCII_8BIT} is considered to be VERY unlikely for human readable texts.
+  # There's no way to know for sure, but {@code Encoding::ASCII_8BIT} is a special encoding that is
+  # usually used for a byte array(/string), not a character string. For those reasons, that encoding
+  # is NOT planned to be allowed for human readable texts by KS in general as well.
   # </p>
   # @param args [...] Something to check.
   # @see <a href="https://ruby-doc.org/core-3.0.0/Encoding.html">Encoding</a>


### PR DESCRIPTION
As can be read in #4, the current implementation of ValidationNotEqualError doesn't output HEX-bytes like in Java, even though those would be better for debugging etc. most likely. This PR brings that output in line with Java, by keeping backwards compatibility with given strings or other objects NOT being byte arrays at all.

The current implementation doesn't need any guessing about the given type, it can either be handled as a byte array or that fails and the former implementation is used instead. This is pretty much the same approach like is [implemented in Java](https://github.com/kaitai-io/kaitai_struct_java_runtime/blob/ea3abf89ee7745ac56c814202c4ddb26fc668e11/src/main/java/io/kaitai/struct/KaitaiStream.java#L604-L615): Two different CTORs exist, one explicitly targeting `byte[]` and the other one being a fallback for everything else using `Object`.

```java
    public static class ValidationNotEqualError extends ValidationFailedError {
        public ValidationNotEqualError(byte[] expected, byte[] actual, KaitaiStream io, String srcPath) {
            super("not equal, expected " + byteArrayToHex(expected) + ", but got " + byteArrayToHex(actual), io, srcPath);
        }

        public ValidationNotEqualError(Object expected, Object actual, KaitaiStream io, String srcPath) {
            super("not equal, expected " + expected + ", but got " + actual, io, srcPath);
        }

        protected Object expected;
        protected Object actual;
    }
```

I don't think using that approach really 1:1 with different method signatures is available in Ruby, so catching an exception seems to be the closest one can get instead. While using exceptions for normal code flow is discouraged in most cases, keep in mind that we have an error condition here already and this way things don't depend on checking encodings or stuff like that. In my opinion, all other guesses aren't any better in the end.

Details why this is necessary can be read at the following discussion:

https://github.com/kaitai-io/kaitai_struct_ruby_runtime/pull/5#pullrequestreview-602122379

This fixes https://github.com/kaitai-io/kaitai_struct_ruby_runtime/issues/4 (again).