### PR TITLE
substream(): ensure identical behavior to read_bytes()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.rb,*.gemspec}]
+[{*.{rb,gemspec},Gemfile}]
 indent_style = space
 indent_size = 2
 max_line_length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,61 @@
+# Created by https://www.toptal.com/developers/gitignore/api/ruby
+# Edit at https://www.toptal.com/developers/gitignore?templates=ruby
+
+### Ruby ###
 *.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+# End of https://www.toptal.com/developers/gitignore/api/ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :test do
+  gem 'rspec', '~> 3.13'
+end
+
+group :development do
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 group :test do
+  gem 'rantly', '~> 3.0'
   gem 'rspec', '~> 3.13'
 end
 

--- a/lib/kaitai/struct/struct.rb
+++ b/lib/kaitai/struct/struct.rb
@@ -683,11 +683,13 @@ class SubIO
     # remember position in parent IO
     old_pos = @parent_io.pos
     @parent_io.seek(@parent_start + @pos)
-    res = @parent_io.getc
-    @pos += 1
-
-    # restore position in parent IO
-    @parent_io.seek(old_pos)
+    begin
+      res = @parent_io.getc
+      @pos += 1
+    ensure
+      # restore position in parent IO
+      @parent_io.seek(old_pos)
+    end
 
     res
   end

--- a/spec/kaitaistream_spec.rb
+++ b/spec/kaitaistream_spec.rb
@@ -97,7 +97,16 @@ RSpec.describe Kaitai::Struct::Stream do
         len = range(0, 8)
         s = array(len) { range(0, 255) }.pack('C*')
         ops = array(10) do
-          sub_len = range(-2, len + 1)
+          sub_len = branch(
+            [:range, -2, len + 1],
+            [:float, :normal, { center: 1, scale: 4 }],
+            :boolean,
+            [:string, :digit],
+            [:literal, [1, 2]],
+            [:literal, nil],
+            [:literal, Complex(2, 0)],
+            [:literal, Complex(2, 1)]
+          )
           options = %i[enter_subio read seek].map { |x| [x, [sub_len]] }
           options.concat(%i[exit_subio eof? pos size getc close_io].map { |x| [x, []] })
 

--- a/spec/kaitaistream_spec.rb
+++ b/spec/kaitaistream_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe Kaitai::Struct::Stream do
       # Check that we can't seek in a socket IO
       expect { stream.seek(2) }.to raise_error(Errno::ESPIPE)
 
+      expect { stream.read_bytes(5) }.to raise_error(EOFError, 'attempted to read 5 bytes, got only 4')
+
       c2s_socket.close
     end
 

--- a/spec/kaitaistream_spec.rb
+++ b/spec/kaitaistream_spec.rb
@@ -3,6 +3,10 @@ require 'stringio'
 require 'socket'
 require 'fileutils'
 
+require 'rspec' # normally not needed, but RubyMine doesn't autocomplete RSpec methods without it
+require 'rantly'
+require 'rantly/rspec_extensions'
+
 RSpec.describe Kaitai::Struct::Stream do
   before(:all) do
     @old_wd = Dir::getwd
@@ -84,6 +88,99 @@ RSpec.describe Kaitai::Struct::Stream do
       expect(io.closed?).to be false
       stream.close
       expect(io.closed?).to be true
+    end
+  end
+
+  describe '#substream' do
+    it 'behaves like #read_bytes + Stream#new' do
+      prop = property_of do
+        len = range(0, 8)
+        s = array(len) { range(0, 255) }.pack('C*')
+        ops = array(10) do
+          sub_len = range(-2, len + 1)
+          options = %i[enter_subio read seek].map { |x| [x, [sub_len]] }
+          options.concat(%i[exit_subio eof? pos size getc close_io].map { |x| [x, []] })
+
+          choose(*options)
+        end
+        [s, ops]
+      end
+      prop.check(2000) do |(s, ops)|
+        StringIO.open { |logger|
+          logger.write("s: #{s.inspect}, length: #{s.bytesize}\n")
+          begin
+            old_streams = [Kaitai::Struct::Stream.new(StringIO.new(s))]
+            new_streams = [Kaitai::Struct::Stream.new(StringIO.new(s))]
+            ops.each do |(op, op_args)|
+              exec_stream_op(op, op_args, old_streams, new_streams, logger)
+            end
+          rescue RSpec::Expectations::ExpectationNotMetError, StandardError
+            $stderr.write("\n#{logger.string}\n")
+            raise
+          end
+        }
+      end
+    end
+
+    def exec_stream_op(op, op_args, old_streams, new_streams, logger)
+      # NB: intentionally without a newline ("\n")
+      logger.write([op, op_args].inspect)
+      old_stream = old_streams.last
+      new_stream = new_streams.last
+      old_io = old_stream.instance_variable_get(:@_io)
+      new_io = new_stream.instance_variable_get(:@_io)
+      case op
+      when :read, :seek, :eof?, :pos, :size, :getc
+        status, ret = call_io_method(op, op_args, old_io, new_io)
+        case status
+        when :ok
+          old_res, new_res = ret
+          expect(new_res).to eq(old_res)
+          logger.write(" -> #{old_res.inspect}\n")
+          if old_res.is_a?(String)
+            expect(new_res.encoding).to eq(old_res.encoding)
+            expect(new_res.frozen?).to eq(old_res.frozen?)
+          end
+        when :fail
+          logger.write(": #{ret.inspect}\n")
+        end
+      when :enter_subio
+        status, ret = call_io_method(:substream, op_args, old_stream, new_stream, :read_bytes)
+        case status
+        when :ok
+          old_res, new_res = ret
+          logger.write(": OK\n")
+          old_streams << Kaitai::Struct::Stream.new(old_res)
+          new_streams << new_res
+        when :fail
+          logger.write(": #{ret.inspect}\n")
+        end
+      when :exit_subio
+        if old_streams.length > 1
+          old_streams.pop.close
+          new_streams.pop.close
+          logger.write(": OK\n")
+        else
+          logger.write(": ignored\n")
+        end
+      when :close_io
+        expect(new_stream.close).to eq(old_stream.close)
+        logger.write(": OK\n")
+      else
+        raise "unknown operation #{op.inspect}"
+      end
+    end
+
+    def call_io_method(method_new, op_args, old_io, new_io, method_old = method_new)
+      old_res = old_io.public_send(method_old, *op_args)
+    rescue StandardError => old_err
+      expect do
+        new_io.public_send(method_new, *op_args)
+      end.to raise_error(old_err.class, old_err.message)
+      [:fail, old_err]
+    else
+      new_res = new_io.public_send(method_new, *op_args)
+      [:ok, [old_res, new_res]]
     end
   end
 end

--- a/spec/subio_spec.rb
+++ b/spec/subio_spec.rb
@@ -225,5 +225,13 @@ RSpec.describe Kaitai::Struct::SubIO do
         end
       end
     end
+
+    describe "#getc" do
+      it 'restores parent pos if parent #getc fails' do
+        @io.parent_io.close_read
+        expect { @io.getc }.to raise_error(IOError)
+        expect(@io.parent_io.pos).to eq(0)
+      end
+    end
   end
 end

--- a/spec/subio_spec.rb
+++ b/spec/subio_spec.rb
@@ -134,6 +134,11 @@ RSpec.describe Kaitai::Struct::SubIO do
         expect(@io.read(2)).to eq("23")
       end
 
+      it "reads 23 when asked to read 2.7" do
+        expect(@normal_io.read(2.7)).to eq("23")
+        expect(@io.read(2.7)).to eq("23")
+      end
+
       it "reads 234 when asked to read 3" do
         expect(@normal_io.read(3)).to eq("234")
         expect(@io.read(3)).to eq("234")


### PR DESCRIPTION
Fixes the `{Eof,Eos}ExceptionSized` tests in Ruby (see https://github.com/kaitai-io/ci_artifacts/blob/d7568fe794b09292b98873dcdc1a5534928345b6/test_out/ruby/ci.json#L314-L324)

Overall, this PR tries to ensure that the zero-copy substreams (https://github.com/kaitai-io/kaitai_struct/issues/44) are a drop-in replacement for the old way using `read_bytes` + `Stream#new` without any observable differences. It's not perfect, but it should be close enough.

To verify this, we automatically generate and evaluate 2000 random scenarios using https://github.com/rantly-rb/rantly involving 10 stream operations and compare whether the old and new substream implementations behave the same. If not, the test will fail. It is a normal RSpec test, so it can be run along with other unit tests using `rspec spec/` on the command line.

Every single change made to the stream implementation follows from a particular edge case identified by this extensive testing.